### PR TITLE
Support identity attribute inheritance

### DIFF
--- a/Groot/Private/NSEntityDescription+Groot.m
+++ b/Groot/Private/NSEntityDescription+Groot.m
@@ -26,13 +26,20 @@
 @implementation NSEntityDescription (Groot)
 
 - (NSAttributeDescription *)grt_identityAttribute {
-    NSString *identityAttribute = self.userInfo[GRTIdentityAttributeKey];
-    
-    if (identityAttribute) {
-        return self.attributesByName[identityAttribute];
-    }
-    
-    return nil;
+	
+	NSString * identityAttribute = nil;
+	NSEntityDescription * entityDescription = self;
+	
+	while (entityDescription && !identityAttribute) {
+		identityAttribute = entityDescription.userInfo[GRTIdentityAttributeKey];
+		entityDescription = entityDescription.superentity;
+	}
+	
+	if (identityAttribute) {
+		return self.attributesByName[identityAttribute];
+	}
+	
+	return nil;
 }
 
 @end


### PR DESCRIPTION
If the identity attribute is not defined for a entity, Groot search for it in its super entities.
