### PR TITLE
Add support for JSON dictionary preprocessing

### DIFF
--- a/Documentation/Annotations.md
+++ b/Documentation/Annotations.md
@@ -129,3 +129,28 @@ Finally we create the entity mapper and give it the name we just used:
     return entityMapping[type];
 }];
 ```
+
+### `JSONDictionaryTransformerName`
+
+This is an optional key you can specify at entity level that contains the name of a value transformer that will be used to transform the JSON dictionaries before serializing them to the target entity.
+
+Think about it as an optional preprocessing step for your JSON.
+
+Consider the situation in which we need to support both legacy and current JSON specs for one of the entities in the model. We could add a `JSONDictionaryTransformerName` entry and create the corresponding dictionary transformer:
+
+```objc
+[NSValueTransformer grt_setDictionaryTransformerWithName:@“MyTransformer”
+										  transformBlock:^NSDictionary *(NSDictionary *JSONDictionary) {
+											  id legacyIdentifier = JSONDictionary[@“legacy_id”];
+											  if (legacyIdentifier != nil) {
+												  NSMutableDictionary *dictionary = [JSONDictionary mutableCopy];
+												  dictionary[@“id”] = legacyIdentifier;
+												  
+												  return dictionary;
+											  }
+											  
+											  return JSONDictionary;
+										  }];
+```
+
+This will ‘upgrade’ our legacy JSON objects to the new version which is the one that correctly maps to our entity.

--- a/Groot.xcodeproj/project.pbxproj
+++ b/Groot.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		B42A1D931B56600000309637 /* characters.json in Resources */ = {isa = PBXBuildFile; fileRef = B42A1D911B56600000309637 /* characters.json */; };
 		B42A1D941B56600000309637 /* characters_update.json in Resources */ = {isa = PBXBuildFile; fileRef = B42A1D921B56600000309637 /* characters_update.json */; };
 		B42A1D971B56614600309637 /* NSData+Resource.m in Sources */ = {isa = PBXBuildFile; fileRef = B42A1D961B56614600309637 /* NSData+Resource.m */; };
+		B44B7F5A1B7240FD00490641 /* NSArray+DictionaryTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = B44B7F581B7240FD00490641 /* NSArray+DictionaryTransformer.h */; };
+		B44B7F5B1B7240FD00490641 /* NSArray+DictionaryTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = B44B7F591B7240FD00490641 /* NSArray+DictionaryTransformer.m */; };
+		B44B7F5C1B72441D00490641 /* NSArray+DictionaryTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = B44B7F581B7240FD00490641 /* NSArray+DictionaryTransformer.h */; };
 		B46200C21B4F07E4003B3B69 /* GRTError.h in Headers */ = {isa = PBXBuildFile; fileRef = B46200C01B4F07E4003B3B69 /* GRTError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B46200C31B4F07E4003B3B69 /* GRTError.m in Sources */ = {isa = PBXBuildFile; fileRef = B46200C11B4F07E4003B3B69 /* GRTError.m */; };
 		B475B4101B53FCE1001F29FE /* NSManagedObject+Groot.h in Headers */ = {isa = PBXBuildFile; fileRef = B475B40E1B53FCE1001F29FE /* NSManagedObject+Groot.h */; };
@@ -96,6 +99,8 @@
 		B42A1D921B56600000309637 /* characters_update.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = characters_update.json; sourceTree = "<group>"; };
 		B42A1D951B56614600309637 /* NSData+Resource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Resource.h"; sourceTree = "<group>"; };
 		B42A1D961B56614600309637 /* NSData+Resource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Resource.m"; sourceTree = "<group>"; };
+		B44B7F581B7240FD00490641 /* NSArray+DictionaryTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+DictionaryTransformer.h"; sourceTree = "<group>"; };
+		B44B7F591B7240FD00490641 /* NSArray+DictionaryTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+DictionaryTransformer.m"; sourceTree = "<group>"; };
 		B46200C01B4F07E4003B3B69 /* GRTError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GRTError.h; sourceTree = "<group>"; };
 		B46200C11B4F07E4003B3B69 /* GRTError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GRTError.m; sourceTree = "<group>"; };
 		B475B40E1B53FCE1001F29FE /* NSManagedObject+Groot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+Groot.h"; sourceTree = "<group>"; };
@@ -259,6 +264,8 @@
 				B4DC1B161AA9CAC200F67403 /* NSEntityDescription+Groot.m */,
 				B475B40E1B53FCE1001F29FE /* NSManagedObject+Groot.h */,
 				B475B40F1B53FCE1001F29FE /* NSManagedObject+Groot.m */,
+				B44B7F581B7240FD00490641 /* NSArray+DictionaryTransformer.h */,
+				B44B7F591B7240FD00490641 /* NSArray+DictionaryTransformer.m */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -276,6 +283,7 @@
 				B408737D1B5AB8470063F150 /* GRTError.h in Headers */,
 				B408738A1B5AB87F0063F150 /* NSAttributeDescription+Groot.h in Headers */,
 				B40873881B5AB87F0063F150 /* NSPropertyDescription+Groot.h in Headers */,
+				B44B7F5C1B72441D00490641 /* NSArray+DictionaryTransformer.h in Headers */,
 				B408738E1B5AB87F0063F150 /* NSManagedObject+Groot.h in Headers */,
 				B40873811B5AB8470063F150 /* GRTManagedStore.h in Headers */,
 				B40873861B5AB87F0063F150 /* GRTValueTransformer.h in Headers */,
@@ -293,6 +301,7 @@
 				B4DC1B271AA9CAC200F67403 /* NSPropertyDescription+Groot.h in Headers */,
 				B4DC1AF21AA9CA5E00F67403 /* Groot.h in Headers */,
 				B4DC1B1D1AA9CAC200F67403 /* GRTManagedStore.h in Headers */,
+				B44B7F5A1B7240FD00490641 /* NSArray+DictionaryTransformer.h in Headers */,
 				B4DC1B1B1AA9CAC200F67403 /* GRTJSONSerialization.h in Headers */,
 				B475B4101B53FCE1001F29FE /* NSManagedObject+Groot.h in Headers */,
 				B4E72F5C1B4DB8EF00B9EA77 /* GRTValueTransformer.h in Headers */,
@@ -493,6 +502,7 @@
 			files = (
 				B4E72F6D1B4DC4D500B9EA77 /* NSValueTransformer+Groot.swift in Sources */,
 				B4DC1B281AA9CAC200F67403 /* NSPropertyDescription+Groot.m in Sources */,
+				B44B7F5B1B7240FD00490641 /* NSArray+DictionaryTransformer.m in Sources */,
 				B4FD30711B569F1A002392F7 /* Groot.swift in Sources */,
 				B4DC1B261AA9CAC200F67403 /* NSEntityDescription+Groot.m in Sources */,
 				B4E72F651B4DB9B300B9EA77 /* NSValueTransformer+Groot.m in Sources */,
@@ -784,6 +794,7 @@
 				B40873761B5AB6930063F150 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		B408737A1B5AB6930063F150 /* Build configuration list for PBXNativeTarget "Groot-MacTests" */ = {
 			isa = XCConfigurationList;
@@ -792,6 +803,7 @@
 				B40873781B5AB6930063F150 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		B4DC1AE61AA9CA5E00F67403 /* Build configuration list for PBXProject "Groot" */ = {
 			isa = XCConfigurationList;

--- a/Groot.xcodeproj/project.pbxproj
+++ b/Groot.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		B44B7F5A1B7240FD00490641 /* NSArray+DictionaryTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = B44B7F581B7240FD00490641 /* NSArray+DictionaryTransformer.h */; };
 		B44B7F5B1B7240FD00490641 /* NSArray+DictionaryTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = B44B7F591B7240FD00490641 /* NSArray+DictionaryTransformer.m */; };
 		B44B7F5C1B72441D00490641 /* NSArray+DictionaryTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = B44B7F581B7240FD00490641 /* NSArray+DictionaryTransformer.h */; };
+		B44B7F5D1B7299B800490641 /* NSArray+DictionaryTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = B44B7F591B7240FD00490641 /* NSArray+DictionaryTransformer.m */; };
 		B46200C21B4F07E4003B3B69 /* GRTError.h in Headers */ = {isa = PBXBuildFile; fileRef = B46200C01B4F07E4003B3B69 /* GRTError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B46200C31B4F07E4003B3B69 /* GRTError.m in Sources */ = {isa = PBXBuildFile; fileRef = B46200C11B4F07E4003B3B69 /* GRTError.m */; };
 		B475B4101B53FCE1001F29FE /* NSManagedObject+Groot.h in Headers */ = {isa = PBXBuildFile; fileRef = B475B40E1B53FCE1001F29FE /* NSManagedObject+Groot.h */; };
@@ -471,6 +472,7 @@
 			files = (
 				B408738D1B5AB87F0063F150 /* NSEntityDescription+Groot.m in Sources */,
 				B40873891B5AB87F0063F150 /* NSPropertyDescription+Groot.m in Sources */,
+				B44B7F5D1B7299B800490641 /* NSArray+DictionaryTransformer.m in Sources */,
 				B40873851B5AB8470063F150 /* NSValueTransformer+Groot.swift in Sources */,
 				B40873801B5AB8470063F150 /* GRTJSONSerialization.m in Sources */,
 				B40873841B5AB8470063F150 /* NSValueTransformer+Groot.m in Sources */,

--- a/Groot/Groot.swift
+++ b/Groot/Groot.swift
@@ -44,8 +44,7 @@ extension NSManagedObject {
             }
         }
         
-        assert(false, "Could not locate the entity for \(className).")
-        return NSEntityDescription()
+        fatalError("Could not locate the entity for \(className).")
     }
 }
 

--- a/Groot/NSValueTransformer+Groot.h
+++ b/Groot/NSValueTransformer+Groot.h
@@ -49,11 +49,23 @@ typedef __nullable id (^GRTTransformBlock)(id value);
                   reverseTransformBlock:(__nullable id (^)(id value))reverseTransformBlock;
 
 /**
+ Registers a dictionary transformer with a given name and transform block.
+ 
+ Dictionary transformers can be associated with Core Data entities in the user info
+ dictionary by using the `JSONDictionaryTransformerName` key.
+ 
+ @param name The name of the transformer.
+ @param transformBlock The block that performs the transformation.
+ */
++ (void)grt_setDictionaryTransformerWithName:(NSString *)name
+                              transformBlock:(NSDictionary * __nullable (^)(NSDictionary *value))transformBlock;
+
+/**
  Registers an entity mapper with a given name and map block.
  
  An entity mapper maps a JSON dictionary to an entity name.
  
- Entity mappers can be associated with abstract core data entities in the user info
+ Entity mappers can be associated with abstract Core Data entities in the user info
  dictionary by using the `entityMapperName` key.
  
  @param name The name of the mapper.

--- a/Groot/NSValueTransformer+Groot.m
+++ b/Groot/NSValueTransformer+Groot.m
@@ -42,6 +42,12 @@ NS_ASSUME_NONNULL_BEGIN
     [self setValueTransformer:valueTransformer forName:name];
 }
 
++ (void)grt_setDictionaryTransformerWithName:(NSString *)name
+                              transformBlock:(NSDictionary * __nullable (^)(NSDictionary *value))transformBlock
+{
+    return [self grt_setValueTransformerWithName:name transformBlock:transformBlock];
+}
+
 + (void)grt_setEntityMapperWithName:(NSString *)name
                            mapBlock:(NSString * __nullable (^)(NSDictionary *JSONDictionary))mapBlock
 {

--- a/Groot/NSValueTransformer+Groot.swift
+++ b/Groot/NSValueTransformer+Groot.swift
@@ -22,14 +22,14 @@
 
 import Foundation
 
-public extension NSValueTransformer {
+extension NSValueTransformer {
     /**
      Registers a value transformer with a given name and transform function.
     
      :param: name The name of the transformer.
      :param: transform The function that performs the transformation.
     */
-    class func setValueTransformerWithName<T, U>(name: String, transform: (T) -> (U?)) {
+    public class func setValueTransformerWithName<T, U>(name: String, transform: (T) -> (U?)) {
         grt_setValueTransformerWithName(name) { value in
             (value as? T).flatMap {
                 transform($0) as? AnyObject
@@ -44,7 +44,7 @@ public extension NSValueTransformer {
      :param: transform The function that performs the forward transformation.
      :param: reverseTransform The function that performs the reverse transformation.
     */
-    class func setValueTransformerWithName<T, U>(name: String, transform: (T) -> (U?), reverseTransform: (U) -> (T?)) {
+    public class func setValueTransformerWithName<T, U>(name: String, transform: (T) -> (U?), reverseTransform: (U) -> (T?)) {
         grt_setValueTransformerWithName(name, transformBlock: { value in
             return (value as? T).flatMap {
                 transform($0) as? AnyObject
@@ -54,6 +54,24 @@ public extension NSValueTransformer {
                     reverseTransform($0) as? AnyObject
                 }
         })
+    }
+    
+    /**
+     Registers a dictionary transformer with a given name and transform function.
+ 
+     Dictionary transformers can be associated with Core Data entities in the user info
+     dictionary by using the `JSONDictionaryTransformerName` key.
+ 
+     :param: name The name of the transformer.
+     :param: transform The function that performs the transformation.
+    */
+    public class func setDictionaryTransformerWithName(name: String, transform: ([String: AnyObject]) -> ([String: AnyObject]?)) {
+        grt_setDictionaryTransformerWithName(name) { value in
+            if let dictionary = value as? [String: AnyObject] {
+                return transform(dictionary)
+            }
+            return nil
+        }
     }
     
     /**
@@ -67,7 +85,7 @@ public extension NSValueTransformer {
      :param: name The name of the mapper.
      :param: map The function that performs the mapping.
     */
-    class func setEntityMapperWithName(name: String, map: ([String: AnyObject]) -> (String?)) {
+    public class func setEntityMapperWithName(name: String, map: ([String: AnyObject]) -> (String?)) {
         grt_setEntityMapperWithName(name) { value in
             if let dictionary = value as? [String: AnyObject] {
                 return map(dictionary)

--- a/Groot/Private/NSArray+DictionaryTransformer.h
+++ b/Groot/Private/NSArray+DictionaryTransformer.h
@@ -1,0 +1,19 @@
+//
+//  NSArray+DictionaryTransformer.h
+//  Groot
+//
+//  Created by Guillermo Gonzalez on 05/08/15.
+//  Copyright (c) 2015 Guillermo Gonzalez. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSArray (DictionaryTransformer)
+
+- (NSArray *)grt_arrayByApplyingDictionaryTransformer:(NSValueTransformer *)valueTransformer;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Groot/Private/NSArray+DictionaryTransformer.m
+++ b/Groot/Private/NSArray+DictionaryTransformer.m
@@ -1,0 +1,33 @@
+//
+//  NSArray+DictionaryTransformer.m
+//  Groot
+//
+//  Created by Guillermo Gonzalez on 05/08/15.
+//  Copyright (c) 2015 Guillermo Gonzalez. All rights reserved.
+//
+
+#import "NSArray+DictionaryTransformer.h"
+
+@implementation NSArray (DictionaryTransformer)
+
+- (NSArray * __nonnull)grt_arrayByApplyingDictionaryTransformer:(NSValueTransformer * __nonnull)valueTransformer {    
+    NSMutableArray *transformedArray = [NSMutableArray arrayWithCapacity:self.count];
+    
+    for (id object in self) {
+        id transformedObject = nil;
+        
+        if ([object isKindOfClass:[NSDictionary class]]) {
+            transformedObject = [valueTransformer transformedValue:object];
+        }
+        
+        if (transformedObject != nil) {
+            [transformedArray addObject:transformedObject];
+        } else {
+            [transformedArray addObject:object];
+        }
+    }
+    
+    return transformedArray;
+}
+
+@end

--- a/GrootTests/NSValueTransformerTests.swift
+++ b/GrootTests/NSValueTransformerTests.swift
@@ -45,6 +45,27 @@ class NSValueTransformerTests: XCTestCase {
         XCTAssertNil(transformer.reverseTransformedValue(nil), "should handle nil values")
         XCTAssertNil(transformer.reverseTransformedValue("not a number"), "should handle unsupported values")
     }
+    
+    func testDictionaryTransformer() {
+        func preprocessJSONDictionary(dictionary: [String: AnyObject]) -> [String: AnyObject]? {
+            var transformedDictionary = dictionary
+            transformedDictionary["transformed"] = true
+            
+            return transformedDictionary
+        }
+        
+        NSValueTransformer.setDictionaryTransformerWithName("testDictionaryTransformer", transform: preprocessJSONDictionary)
+        
+        let transformer = NSValueTransformer(forName: "testDictionaryTransformer")!
+        let transformedDictionary = transformer.transformedValue(["foo": "bar"]) as! [String: AnyObject]
+        if let transformed = transformedDictionary["transformed"] as? Bool {
+            XCTAssertTrue(transformed, "should call the transform function")
+        } else {
+            XCTFail("Didn't execute the transform function")
+        }
+        
+        XCTAssertNil(transformer.transformedValue(nil), "should handle nil values")
+    }
 
     func testEntityMapper() {
         func entityForJSONDictionary(dictionary: [String: AnyObject]) -> String? {


### PR DESCRIPTION
This PR adds support for an additional entity annotation: `JSONDictionaryTransformerName`.

With this key you can specify the name of a value transformer that will be applied to each JSON dictionary before it gets serialized to the target entity. You can think about it as an optional preprocessing step for the JSON input.

This feature is useful in those situations where you have to deal with slightly different JSON dictionaries for the same kind of object, you can transform them to a single representation before mapping them to Core Data.
