### PR TITLE
Added behavior to serialize a sub-attribute of a relationship

### DIFF
--- a/Groot.podspec
+++ b/Groot.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Groot"
-  s.version      = "1.1"
+  s.version      = "1.1.1"
   s.summary      = "From JSON to Core Data and back."
 
   s.description  = <<-DESC

--- a/Groot/Private/NSManagedObject+Groot.m
+++ b/Groot/Private/NSManagedObject+Groot.m
@@ -121,13 +121,29 @@ NS_ASSUME_NONNULL_BEGIN
                         
                         NSMutableArray *array = [NSMutableArray arrayWithCapacity:managedObjects.count];
                         for (NSManagedObject *managedObject in managedObjects) {
-                            NSDictionary *dictionary = [managedObject grt_JSONDictionarySerializingRelationships:serializingRelationships];
-                            [array addObject:dictionary];
+                            if ([property grt_JSONSerializationPath] != nil) {
+                                NSString *keyPath = [property grt_JSONSerializationPath];
+                                NSObject *value = [managedObject valueForKey:keyPath];
+                                [array addObject:value];
+                            }
+                            else {
+                                NSDictionary *dictionary = [managedObject grt_JSONDictionarySerializingRelationships:serializingRelationships];
+                                [array addObject:dictionary];
+                            }
                         }
                         value = array;
                     } else {
                         NSManagedObject *managedObject = value;
-                        value = [managedObject grt_JSONDictionarySerializingRelationships:serializingRelationships];
+                        
+                        // If we are requesting a sub-attribute to serialize, do so
+                        // Otherwise fallback to the default behavior
+                        if ([property grt_JSONSerializationPath] != nil) {
+                            NSString *keyPath = [property grt_JSONSerializationPath];
+                            value = [managedObject valueForKey:keyPath];
+                        }
+                        else {
+                            value = [managedObject grt_JSONDictionarySerializingRelationships:serializingRelationships];
+                        }
                     }
                 }
             }

--- a/Groot/Private/NSPropertyDescription+Groot.h
+++ b/Groot/Private/NSPropertyDescription+Groot.h
@@ -32,6 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)grt_JSONKeyPath;
 
 /**
+ Used for relationships, identifies which attribute should represent its parent during the serialization process.
+ */
+- (nullable NSString *)grt_JSONSerializationPath;
+
+/**
  Returns `true` if this property should participate in the JSON serialization process.
  */
 - (BOOL)grt_JSONSerializable;

--- a/Groot/Private/NSPropertyDescription+Groot.m
+++ b/Groot/Private/NSPropertyDescription+Groot.m
@@ -28,6 +28,10 @@
     return self.userInfo[@"JSONKeyPath"];
 }
 
+- (nullable NSString *)grt_JSONSerializationPath {
+    return self.userInfo[@"JSONSerializationPath"];
+}
+
 - (BOOL)grt_JSONSerializable {
     return [self grt_JSONKeyPath] != nil;
 }


### PR DESCRIPTION
Allows a user to choose a relationship's attribute to be used in the JSON serialization by adding a "JSONSerializationPath" to the data model.  Discussed in #45 