### PR TITLE
GRTUniquingSerializationStrategy: attribute with null value replaces original value

### DIFF
--- a/Groot.podspec
+++ b/Groot.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.author             = { "Guillermo Gonzalez" => "gonzalezreal@icloud.com" }
   s.social_media_url   = "https://twitter.com/gonzalezreal"
   
-  s.source       = { :git => "https://github.com/gonzalezreal/Groot.git", :tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/ValentinStrazdin/Groot.git", :tag => s.version.to_s }
   
   s.default_subspec = "Swift"
   s.ios.deployment_target = "8.0"

--- a/Groot/Private/NSManagedObject+Groot.m
+++ b/Groot/Private/NSManagedObject+Groot.m
@@ -164,14 +164,12 @@ NS_ASSUME_NONNULL_BEGIN
     id value = nil;
     id rawValue = [attribute grt_rawValueInJSONDictionary:dictionary];
     
-    if (rawValue != nil) {
-        if (rawValue != [NSNull null]) {
-            NSValueTransformer *transformer = [attribute grt_JSONTransformer];
-            if (transformer) {
-                value = [transformer transformedValue:rawValue];
-            } else {
-                value = rawValue;
-            }
+    if (rawValue != nil && rawValue != [NSNull null]) {
+        NSValueTransformer *transformer = [attribute grt_JSONTransformer];
+        if (transformer) {
+            value = [transformer transformedValue:rawValue];
+        } else {
+            value = rawValue;
         }
     } else if (mergeChanges) {
         // Just validate the current value


### PR DESCRIPTION
I have NSManagedObject with identity attribute. This object has several nullable properties.
I set values for these properties and save NSManagedObjectContext.
When I get JSON from server containing list of objects I want to merge these changes with my existing objects. Although corresponding attributes are null my saved properties are replaced with these nulls.