### PR TITLE
Changed className string to use the class name

### DIFF
--- a/Groot/Groot.swift
+++ b/Groot/Groot.swift
@@ -45,7 +45,7 @@ extension NSManagedObject {
             fatalError("Could not find managed object model for the provided context.")
         }
 
-        let className = String(reflecting: self)
+        let className = String(describing: self)
 
         for entity in model.entities {
             if entity.managedObjectClassName == className {


### PR DESCRIPTION
Changed className string to use the class name only and not the containing module for CoreData implementations that span more than one module.

This was causing a problem when the .xcdatamodeld was contained in a Cocoapod and not the application.