### PR TITLE
Ability to modify objects after being imported using Groot

### DIFF
--- a/Groot.xcodeproj/project.pbxproj
+++ b/Groot.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		72A313E721CBC0EF00B7729C /* NSManagedObject+GrootPublic.h in Headers */ = {isa = PBXBuildFile; fileRef = 72A313E521CBC0EE00B7729C /* NSManagedObject+GrootPublic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72A313E821CBC0EF00B7729C /* NSManagedObject+GrootPublic.h in Headers */ = {isa = PBXBuildFile; fileRef = 72A313E521CBC0EE00B7729C /* NSManagedObject+GrootPublic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		72A313E921CBC0EF00B7729C /* NSManagedObject+GrootPublic.m in Sources */ = {isa = PBXBuildFile; fileRef = 72A313E621CBC0EF00B7729C /* NSManagedObject+GrootPublic.m */; };
+		72A313EA21CBC0EF00B7729C /* NSManagedObject+GrootPublic.m in Sources */ = {isa = PBXBuildFile; fileRef = 72A313E621CBC0EF00B7729C /* NSManagedObject+GrootPublic.m */; };
 		82BCF4DD1D9123BF00BC4E0F /* Data+Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BCF4DC1D9123BF00BC4E0F /* Data+Resource.swift */; };
 		82BCF4DF1D913EF700BC4E0F /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BCF4DE1D913EF700BC4E0F /* Models.swift */; };
 		82BCF4E71D9145DE00BC4E0F /* SerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82BCF4E61D9145DE00BC4E0F /* SerializationTests.swift */; };
@@ -117,6 +121,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		72A313E521CBC0EE00B7729C /* NSManagedObject+GrootPublic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSManagedObject+GrootPublic.h"; sourceTree = "<group>"; };
+		72A313E621CBC0EF00B7729C /* NSManagedObject+GrootPublic.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSManagedObject+GrootPublic.m"; sourceTree = "<group>"; };
 		82BCF4DC1D9123BF00BC4E0F /* Data+Resource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Resource.swift"; sourceTree = "<group>"; };
 		82BCF4DE1D913EF700BC4E0F /* Models.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		82BCF4E61D9145DE00BC4E0F /* SerializationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SerializationTests.swift; sourceTree = "<group>"; };
@@ -268,6 +274,8 @@
 				B4E72F621B4DB9B300B9EA77 /* NSValueTransformer+Groot.h */,
 				B4E72F631B4DB9B300B9EA77 /* NSValueTransformer+Groot.m */,
 				B4E72F6C1B4DC4D500B9EA77 /* ValueTransformer+Groot.swift */,
+				72A313E521CBC0EE00B7729C /* NSManagedObject+GrootPublic.h */,
+				72A313E621CBC0EF00B7729C /* NSManagedObject+GrootPublic.m */,
 				B4DC1B101AA9CAC200F67403 /* Private */,
 				B4DC1AEF1AA9CA5E00F67403 /* Supporting Files */,
 			);
@@ -340,6 +348,7 @@
 			files = (
 				B408738C1B5AB87F0063F150 /* NSEntityDescription+Groot.h in Headers */,
 				B4E314FD1B832EF900A80489 /* GRTSerializationStrategy.h in Headers */,
+				72A313E821CBC0EF00B7729C /* NSManagedObject+GrootPublic.h in Headers */,
 				B4EB88B91B847E2100867F3F /* GRTCompositeUniquingSerializationStrategy.h in Headers */,
 				B408737B1B5AB8350063F150 /* Groot.h in Headers */,
 				B40873831B5AB8470063F150 /* NSValueTransformer+Groot.h in Headers */,
@@ -363,6 +372,7 @@
 			files = (
 				B46200C21B4F07E4003B3B69 /* GRTError.h in Headers */,
 				B4E314FE1B832EFA00A80489 /* GRTSerializationStrategy.h in Headers */,
+				72A313E721CBC0EF00B7729C /* NSManagedObject+GrootPublic.h in Headers */,
 				B4EB88B61B847D3800867F3F /* GRTCompositeUniquingSerializationStrategy.h in Headers */,
 				B4E72F641B4DB9B300B9EA77 /* NSValueTransformer+Groot.h in Headers */,
 				B4DC1B251AA9CAC200F67403 /* NSEntityDescription+Groot.h in Headers */,
@@ -558,6 +568,7 @@
 				B40873851B5AB8470063F150 /* ValueTransformer+Groot.swift in Sources */,
 				B4944D151B83305600EA2D29 /* GRTInsertSerializationStrategy.m in Sources */,
 				B40873801B5AB8470063F150 /* GRTJSONSerialization.m in Sources */,
+				72A313EA21CBC0EF00B7729C /* NSManagedObject+GrootPublic.m in Sources */,
 				B40873841B5AB8470063F150 /* NSValueTransformer+Groot.m in Sources */,
 				B408737E1B5AB8470063F150 /* GRTError.m in Sources */,
 				B408737C1B5AB83D0063F150 /* Groot.swift in Sources */,
@@ -595,6 +606,7 @@
 				B4FD30711B569F1A002392F7 /* Groot.swift in Sources */,
 				B4944D131B83303B00EA2D29 /* GRTInsertSerializationStrategy.m in Sources */,
 				B4DC1B261AA9CAC200F67403 /* NSEntityDescription+Groot.m in Sources */,
+				72A313E921CBC0EF00B7729C /* NSManagedObject+GrootPublic.m in Sources */,
 				B4E72F651B4DB9B300B9EA77 /* NSValueTransformer+Groot.m in Sources */,
 				B4DC1B1C1AA9CAC200F67403 /* GRTJSONSerialization.m in Sources */,
 				B4DC1B221AA9CAC200F67403 /* NSAttributeDescription+Groot.m in Sources */,

--- a/Groot/Groot.h
+++ b/Groot/Groot.h
@@ -32,3 +32,4 @@ FOUNDATION_EXPORT const unsigned char GrootVersionString[];
 #import <Groot/GRTManagedStore.h>
 #import <Groot/NSValueTransformer+Groot.h>
 #import <Groot/GRTJSONSerialization.h>
+#import <Groot/NSManagedObject+GrootPublic.h>

--- a/Groot/NSManagedObject+GrootPublic.h
+++ b/Groot/NSManagedObject+GrootPublic.h
@@ -1,0 +1,17 @@
+//
+//  NSManagedObject+GrootPublic.h
+//  Groot
+//
+//  Created by Manuel García-Estañ on 20/12/2018.
+//  Copyright © 2018 Guillermo Gonzalez. All rights reserved.
+//
+
+#import <CoreData/CoreData.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSManagedObject (GrootPublic)
+- (void) grt_awakeFromInsert;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Groot/NSManagedObject+GrootPublic.m
+++ b/Groot/NSManagedObject+GrootPublic.m
@@ -1,0 +1,19 @@
+//
+//  NSManagedObject+GrootPublic.m
+//  Groot
+//
+//  Created by Manuel García-Estañ on 20/12/2018.
+//  Copyright © 2018 Guillermo Gonzalez. All rights reserved.
+//
+
+#import "NSManagedObject+GrootPublic.h"
+
+@implementation NSManagedObject (GrootPublic)
+
+/**
+ Called just after the object has been inserted or updated using Groot.
+ */
+- (void)grt_awakeFromInsert {
+	// Empty on purpose. It is intended to be subclassed
+}
+@end

--- a/Groot/Private/NSManagedObject+Groot.m
+++ b/Groot/Private/NSManagedObject+Groot.m
@@ -27,6 +27,7 @@
 
 #import "NSPropertyDescription+Groot.h"
 #import "NSAttributeDescription+Groot.h"
+#import "NSManagedObject+GrootPublic.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -55,9 +56,13 @@ NS_ASSUME_NONNULL_BEGIN
         *stop = (error != nil); // break on error
     }];
     
-    if (error != nil && outError != nil) {
-        *outError = error;
-    }
+	if (error != nil) {
+		if (outError != nil) {
+        	*outError = error;
+		}
+	} else {
+		[self grt_awakeFromInsert];
+	}
 }
 
 - (void)grt_serializeJSONValue:(id)value
@@ -68,6 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
     
     if ([self validateValue:&identifier forKey:attribute.name error:outError]) {
         [self setValue:identifier forKey:attribute.name];
+		[self grt_awakeFromInsert];
     }
 }
 

--- a/GrootTests/Models.swift
+++ b/GrootTests/Models.swift
@@ -7,6 +7,7 @@
 //
 
 import CoreData
+import Groot
 
 final class Character: NSManagedObject {
 
@@ -15,6 +16,13 @@ final class Character: NSManagedObject {
     @NSManaged var realName: String
     @NSManaged var publisher: Publisher?
     @NSManaged var powers: Set<Power>
+	
+	var awakeFromInsertCalled = false
+	
+	override func grt_awakeFromInsert() {
+		super.grt_awakeFromInsert()
+		awakeFromInsertCalled = true
+	}
 }
 
 final class Publisher: NSManagedObject {
@@ -29,6 +37,13 @@ final class Power: NSManagedObject {
     @NSManaged var identifier: Int
     @NSManaged var name: String
     @NSManaged var characters: Set<Character>
+	
+	var awakeFromInsertCalled = false
+	
+	override func grt_awakeFromInsert() {
+		super.grt_awakeFromInsert()
+		awakeFromInsertCalled = true
+	}
 }
 
 final class Container: NSManagedObject {

--- a/GrootTests/SerializationTests.swift
+++ b/GrootTests/SerializationTests.swift
@@ -95,6 +95,7 @@ class SerializationTests: XCTestCase {
             XCTAssertEqual(1699, batman.identifier)
             XCTAssertEqual("Batman", batman.name)
             XCTAssertEqual("Bruce Wayne", batman.realName)
+			XCTAssertTrue(batman.awakeFromInsertCalled)
 
             let powers = batman.powers.sorted(by: identifierAscending)
 
@@ -194,7 +195,7 @@ class SerializationTests: XCTestCase {
             XCTFail()
             return
         }
-
+		
         let updateJSON: JSONArray = [
             [
                 "id": "1699",
@@ -242,7 +243,8 @@ class SerializationTests: XCTestCase {
         XCTAssertEqual("Iron Man", ironMan.name)
         XCTAssertEqual(1455, ironMan.identifier)
         XCTAssertEqual("Tony Stark", ironMan.realName)
-
+		XCTAssertTrue(ironMan.awakeFromInsertCalled)
+		
         var powers = ironMan.powers.sorted(by: identifierAscending)
 
         let ironManRich = powers[0];
@@ -260,7 +262,8 @@ class SerializationTests: XCTestCase {
         XCTAssertEqual("Batman", batman.name)
         XCTAssertEqual(1699, batman.identifier)
         XCTAssertEqual("Bruce Wayne", batman.realName)
-
+		XCTAssertTrue(batman.awakeFromInsertCalled)
+		
         powers = batman.powers.sorted(by: identifierAscending)
 
         let agility = powers[0]
@@ -325,8 +328,10 @@ class SerializationTests: XCTestCase {
 
             XCTAssertEqual("Character", characters[0].entity.name)
             XCTAssertEqual(1699, characters[0].identifier)
+			XCTAssertTrue(characters[0].awakeFromInsertCalled)
             XCTAssertEqual("Character", characters[1].entity.name)
             XCTAssertEqual(1455, characters[1].identifier)
+			XCTAssertTrue(characters[1].awakeFromInsertCalled)
         } catch {
             XCTFail("error: \(error)")
         }
@@ -342,7 +347,7 @@ class SerializationTests: XCTestCase {
             "name": "Batman",
             "real_name": "Bruce Wayne",
             "id": "1699",
-            "powers": ["4", NSNull(), "9"],
+            "powers": ["4", NSNull(), "9", "10"],
             "publisher": "10"
         ]
 
@@ -367,7 +372,7 @@ class SerializationTests: XCTestCase {
             let _: [Power] = try objects(fromJSONArray: powersJSON, inContext: context)
             let _: Publisher = try object(fromJSONDictionary: publisherJSON, inContext: context)
 
-            XCTAssertEqual(2, batman.powers.count)
+            XCTAssertEqual(3, batman.powers.count)
 
             let powers = batman.powers.sorted(by: identifierAscending)
 
@@ -380,6 +385,11 @@ class SerializationTests: XCTestCase {
 
             XCTAssertEqual(9, wealth.identifier)
             XCTAssertEqual("Insanely Rich", wealth.name)
+			
+			let unknownPower = powers[2]
+			
+			XCTAssertEqual(10, unknownPower.identifier)
+			XCTAssertTrue(unknownPower.awakeFromInsertCalled)
 
             let publisher = batman.publisher
 


### PR DESCRIPTION
The changes contained on this PR add the ability to modify an object after being inserted/update using **Groot** in a consistent way. 

It just adds a category to `NSManagedObject` with the method `grt_awakeFromInsert` that is called after each insert/update operation. This method can be overridden by any subclass.

This is a possible solution for the issue described in #93 . 

If you like the idea but you want me to change something let me know.